### PR TITLE
fix(agents): refactor AgentSetupInstructions to avoid template litera…

### DIFF
--- a/app/components/agent/AgentQuickActions.vue
+++ b/app/components/agent/AgentQuickActions.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { Card, CardHeader, CardTitle, CardContent, Button } from "#components";
 import { PlayIcon, SettingsIcon, BookmarkIcon } from "lucide-vue-next";
+import AgentSetupInstructions from "~/components/agent/AgentSetupInstructions.vue";
+
+const showSetup = ref(false);
+
+// mocks
+const agentKey = "i2fcbogcbc4eu618ycac3";
+const backendUrl = "https://pentulz.xyz/";
 </script>
 
 <template>
@@ -13,10 +20,7 @@ import { PlayIcon, SettingsIcon, BookmarkIcon } from "lucide-vue-next";
     </CardHeader>
 
     <CardContent class="flex flex-col gap-2">
-      <Button
-        variant="outline"
-        class="w-full justify-start gap-2"
-      >
+      <Button variant="outline" class="w-full justify-start gap-2">
         <PlayIcon class="w-4 h-4" />
         Start New Job
       </Button>
@@ -24,10 +28,19 @@ import { PlayIcon, SettingsIcon, BookmarkIcon } from "lucide-vue-next";
       <Button
         variant="outline"
         class="w-full justify-start gap-2"
+        @click="showSetup = true"
       >
         <SettingsIcon class="w-4 h-4" />
         Configure Agent
       </Button>
     </CardContent>
   </Card>
+
+  <!-- Popup -->
+  <AgentSetupInstructions
+    :open="showSetup"
+    :on-close="() => (showSetup = false)"
+    :agent-key="agentKey"
+    :backend-url="backendUrl"
+  />
 </template>

--- a/app/components/agent/AgentSetupInstructions.vue
+++ b/app/components/agent/AgentSetupInstructions.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "#components";
+import { TerminalIcon, ClipboardIcon } from "lucide-vue-next";
+
+const props = defineProps<{
+  open: boolean;
+  onClose: () => void;
+  agentKey: string;
+  backendUrl: string;
+}>();
+
+function copy(text: string) {
+  navigator.clipboard.writeText(text);
+}
+
+// 🟢 Préparation des commandes
+const dockerCmd = computed(
+  () =>
+    `docker run --rm ghcr.io/pentulz/agent:latest -e KEY="${props.agentKey}" -e BACKEND_URL="${props.backendUrl}"`
+);
+
+const cliCmd = computed(
+  () =>
+    `pentulz_agent --key "${props.agentKey}" --backend "${props.backendUrl}"`
+);
+</script>
+
+<template>
+  <Dialog :open="props.open" @update:open="props.onClose()">
+    <DialogContent class="max-w-2xl bg-orange-50">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2">
+          <TerminalIcon class="w-5 h-5" />
+          Agent Setup Instructions
+        </DialogTitle>
+      </DialogHeader>
+
+      <div class="flex flex-col gap-6 py-2">
+        <!-- Option 1 -->
+        <div class="flex flex-col gap-2">
+          <p class="font-medium">Option 1: Docker Setup</p>
+          <div
+            class="relative bg-neutral-900 text-green-400 rounded-md p-3 font-mono text-sm"
+          >
+            <code>{{ dockerCmd }}</code>
+            <button
+            class="absolute top-2 right-2 text-neutral-400 hover:text-white" @click="copy(dockerCmd)"
+            >
+              <ClipboardIcon class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Option 2 -->
+        <div class="flex flex-col gap-2">
+          <p class="font-medium">Option 2: CLI Setup</p>
+          <button class="border rounded-md px-3 py-2 text-sm w-fit">
+            Download from GitHub Releases
+          </button>
+          <div
+            class="relative bg-neutral-900 text-green-400 rounded-md p-3 font-mono text-sm"
+          >
+            <code>{{ cliCmd }}</code>
+            <button
+            class="absolute top-2 right-2 text-neutral-400 hover:text-white" @click="copy(cliCmd)"
+            >
+              <ClipboardIcon class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>


### PR DESCRIPTION
…l parsing error

- Moved docker and CLI setup commands into computed properties
- Updated copy-to-clipboard handlers to use precomputed strings
- Fixed Vue parsing error caused by inline template literals in @click