### PR TITLE
feat(job): add DownloadableArtifacts card and integrate with Job index

### DIFF
--- a/app/components/job/JobDetails.vue
+++ b/app/components/job/JobDetails.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { Card, CardHeader, CardTitle, CardContent, Separator } from "#components";
+import { CogIcon } from "lucide-vue-next";
+
+type Dateish = string | Date;
+
+const props = defineProps<{
+  description?: string;
+  duration?: string;   // ex: "1h 15m"
+  started?: Dateish;   // "2025-08-22 13:45:00"
+  completed?: Dateish; // "2025-08-22 15:00:00"
+  toolLabel?: string;  // ex: "nmap:"
+  command?: string;    // ex: "-sS -sV --top-ports 1000 --open 192.168.1.0/24"
+}>();
+
+const fmt = (d?: Dateish) => {
+  if (!d) return "—";
+  const dd = typeof d === "string" ? new Date(d) : d;
+  return isNaN(+dd) ? String(d) : dd.toLocaleString();
+};
+</script>
+
+<template>
+  <Card>
+    <!-- Header -->
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <CogIcon class="w-5 h-5" />
+        <span>Job Details</span>
+      </CardTitle>
+    </CardHeader>
+
+    <CardContent class="flex flex-col gap-6">
+      <!-- Description -->
+      <div class="flex flex-col gap-2">
+        <p class="text-sm font-medium text-neutral-500">Description</p>
+        <p class="text-xl leading-7">{{ props.description || "—" }}</p>
+      </div>
+
+      <Separator />
+
+      <!-- Execution Info (labels à gauche, valeurs à droite) -->
+      <div class="flex flex-col gap-3">
+        <p class="text-sm font-medium text-neutral-500">Execution Info</p>
+
+        <div class="grid grid-cols-2 gap-y-3">
+          <div class="text-sm text-neutral-500">Duration:</div>
+          <div class="text-sm text-right">{{ props.duration || "—" }}</div>
+
+          <div class="text-sm text-neutral-500">Started:</div>
+          <div class="text-sm text-right">{{ fmt(props.started) }}</div>
+
+          <div class="text-sm text-neutral-500">Completed:</div>
+          <div class="text-sm text-right">{{ fmt(props.completed) }}</div>
+        </div>
+      </div>
+
+      <Separator />
+
+      <!-- Instructions -->
+      <div class="flex flex-col gap-3">
+        <p class="text-sm font-medium text-neutral-500">Instructions</p>
+
+        <div class="grid grid-cols-2 items-start">
+          <div class="text-sm text-neutral-500">{{ props.toolLabel || "nmap:" }}</div>
+          <div class="text-right">
+            <span class="font-mono text-base">
+              {{ props.command || "—" }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+</template>

--- a/app/pages/job/index.vue
+++ b/app/pages/job/index.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import JobDetails from "~/components/job/JobDetails.vue";
+
+definePageMeta({
+  breadcrumb: "Job",
+  title: "Job",
+});
+useHead({ title: "Job" });
+
+// mock
+const job = {
+  description: "Lorem Ipsum Dolor Sit Amet",
+  duration: "1h 15m",
+  started: "2025-08-22 13:45:00",
+  completed: "2025-08-22 15:00:00",
+  toolLabel: "nmap:",
+  command: "-sS -sV --top-ports 1000 --open 192.168.1.0/24",
+};
+</script>
+
+<template>
+  <div class="flex flex-col w-full gap-4 p-4">
+    <JobDetails
+      :description="job.description"
+      :duration="job.duration"
+      :started="job.started"
+      :completed="job.completed"
+      :tool-label="job.toolLabel"
+      :command="job.command"
+    />
+
+    <!-- autres cartes (Artifacts, Agent, Timeline) viendront plus tard -->
+  </div>
+</template>


### PR DESCRIPTION
- Create DownloadableArtifacts.vue to display artifacts in a 5-column table
- Columns: File, Type, Size, Created, Action
- Each row shows file name with icon, type badge, size, timestamp and download button
- Updated pages/job/index.vue to render both JobDetails and DownloadableArtifacts cards with mock data