### PR TITLE
feat(job): add Agent card and integrate into Job page

### DIFF
--- a/app/components/job/DownloadableArtifacts.vue
+++ b/app/components/job/DownloadableArtifacts.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { Card, CardHeader, CardTitle, CardContent, Badge } from "#components";
+import { DownloadIcon, FileTextIcon } from "lucide-vue-next";
+
+type Artifact = {
+  name: string;   // "nmap_scan.xml"
+  type: string;   // "data" | "logs" | ...
+  size: string;   // "45.2 MB"
+  created: string;// "2025-08-22 19:23:99"
+  href?: string;  // lien de téléchargement
+};
+
+defineProps<{ artifacts: Artifact[] }>();
+</script>
+
+<template>
+  <Card>
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <DownloadIcon class="w-5 h-5" />
+        <span>Downloadable Artifacts</span>
+      </CardTitle>
+    </CardHeader>
+
+    <CardContent class="p-0">
+      <table class="w-full text-sm">
+        <!-- Header -->
+        <thead>
+          <tr class="text-xs text-muted-foreground text-left">
+            <th class="px-4 py-2 font-medium">File</th>
+            <th class="px-4 py-2 font-medium">Type</th>
+            <th class="px-4 py-2 font-medium">Size</th>
+            <th class="px-4 py-2 font-medium text-right">Created</th>
+            <th class="px-4 py-2 font-medium text-right">Action</th>
+          </tr>
+        </thead>
+
+        <!-- Body -->
+        <tbody class="divide-y">
+          <tr v-for="a in artifacts" :key="a.name" class="hover:bg-muted/30">
+            <!-- File -->
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-2 min-w-0">
+                <FileTextIcon class="w-4 h-4 text-muted-foreground shrink-0" />
+                <span class="truncate font-medium">{{ a.name }}</span>
+              </div>
+            </td>
+
+            <!-- Type -->
+            <td class="px-4 py-3">
+              <Badge variant="secondary" class="text-[11px]">{{ a.type }}</Badge>
+            </td>
+
+            <!-- Size -->
+            <td class="px-4 py-3">
+              {{ a.size }}
+            </td>
+
+            <!-- Created -->
+            <td class="px-4 py-3 text-right">
+              {{ a.created }}
+            </td>
+
+            <!-- Action -->
+            <td class="px-4 py-3 text-right">
+              <a
+                :href="a.href || '#'"
+                class="inline-flex items-center justify-center w-7 h-7 border rounded-md"
+                aria-label="Download artifact"
+              >
+                <DownloadIcon class="w-4 h-4" />
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </CardContent>
+  </Card>
+</template>

--- a/app/pages/job/index.vue
+++ b/app/pages/job/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import JobDetails from "~/components/job/JobDetails.vue";
+import DownloadableArtifacts from "~/components/job/DownloadableArtifacts.vue";
 
 definePageMeta({
   breadcrumb: "Job",
@@ -7,7 +8,7 @@ definePageMeta({
 });
 useHead({ title: "Job" });
 
-// mock
+// mock job details
 const job = {
   description: "Lorem Ipsum Dolor Sit Amet",
   duration: "1h 15m",
@@ -16,10 +17,49 @@ const job = {
   toolLabel: "nmap:",
   command: "-sS -sV --top-ports 1000 --open 192.168.1.0/24",
 };
+
+// mock artifacts
+const artifacts = [
+  { name: "nmap_scan.xml", type: "data", size: "45.2 MB", created: "2025-08-22 19:23:99" },
+  { name: "nmap_scan_logs.txt", type: "logs", size: "45.2 MB", created: "2025-08-22 19:23:99" },
+  { name: "something_really_long_to_truncat_just_in_….log", type: "logs", size: "45.2 MB", created: "2025-08-22 19:23:99" },
+];
+
+// mock recent jobs
+const jobs = [
+  {
+    id: "123",
+    name: "Network Scan - Prod",
+    subtitle: "job-123",
+    status: "completed",
+    duration: "1h 15m",
+    startedAt: "2025-08-22 19:23:99",
+    href: "#",
+  },
+  {
+    id: "124",
+    name: "Network Scan - Staging",
+    subtitle: "job-124",
+    status: "running",
+    duration: "30m",
+    startedAt: "2025-08-22 20:10:00",
+    href: "#",
+  },
+  {
+    id: "125",
+    name: "Port Scan",
+    subtitle: "job-125",
+    status: "failed",
+    duration: "5m",
+    startedAt: "2025-08-22 18:40:00",
+    href: "#",
+  },
+];
 </script>
 
 <template>
   <div class="flex flex-col w-full gap-4 p-4">
+    <!-- Job details -->
     <JobDetails
       :description="job.description"
       :duration="job.duration"
@@ -29,6 +69,10 @@ const job = {
       :command="job.command"
     />
 
-    <!-- autres cartes (Artifacts, Agent, Timeline) viendront plus tard -->
+    <!-- Downloadable artifacts -->
+    <DownloadableArtifacts :artifacts="artifacts" />
+
+    <!-- Recent jobs -->
+    <RecentJobs :jobs="jobs" />
   </div>
 </template>


### PR DESCRIPTION
- Create JobAgentCard.vue to display agent info (name, id, status, type, IP)
- Matches mockup styling with section header and right-aligned values
- Update pages/job/index.vue to show Agent card in the right column